### PR TITLE
Bug, security code removing left zero and broken tests

### DIFF
--- a/src/Cielo.Web.Sample/Controllers/LojaBuyPageCartController.cs
+++ b/src/Cielo.Web.Sample/Controllers/LojaBuyPageCartController.cs
@@ -81,7 +81,7 @@ namespace Cielo.Web.Sample.Controllers
 
         public class CheckoutViewModel
         {
-            public int SecurityCode { get; set; }
+            public string SecurityCode { get; set; }
             public string ExpirationYear { get; set; }
             public string ExpirationMonth { get; set; }
             public string CreditCardNumber { get; set; }

--- a/src/Cielo/Requests/Entities/CreditCardData.cs
+++ b/src/Cielo/Requests/Entities/CreditCardData.cs
@@ -10,12 +10,12 @@ namespace Cielo.Requests.Entities
         private readonly CreditCardExpiration _expiration;
         public string Expiration { get { return _expiration.ToString(); } }
         public SecurityCodeIndicator Indicator { get; private set; }
-        public int SecurityCode { get; private set; }
+        public string SecurityCode { get; private set; }
 
         public CreditCardData(string creditCardNumber,
                               CreditCardExpiration expiration,
                               SecurityCodeIndicator indicator,
-                              int securityCode)
+                              string securityCode)
         {
             _expiration = expiration;
             CreditCardNumber = creditCardNumber;

--- a/src/CieloTests/CieloServiceTests.cs
+++ b/src/CieloTests/CieloServiceTests.cs
@@ -1,38 +1,30 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Cielo;
+﻿using Cielo;
 using Cielo.Requests;
 using Cielo.Responses;
 using Cielo.Responses.Exceptions;
 using FluentAssertions;
 using NUnit.Framework;
 
-namespace CieloTests
-{
+namespace CieloTests {
+
     [TestFixture]
-    public class CieloServiceTests
-    {
-        public class CieloServiceFake : CieloService
-        {
+    public class CieloServiceTests {
+
+        public class CieloServiceFake : CieloService {
+
             public CieloServiceFake()
-                : base("http://endpoint.fake.br")
-            {
-            }
+                : base("http://endpoint.fake.br") { }
 
             public string ReturnXml { get; set; }
-            protected override string Execute(ICieloRequest cieloRequest)
-            {
+
+            protected override string Execute(ICieloRequest cieloRequest) {
                 return ReturnXml;
             }
         }
 
         [Test]
-        public void CreateTransaction_WhenXmlResponseDoesNotContainError_ShouldReturnCreateTransactionResponse()
-        {
-            var service = new CieloServiceFake()
-            {
+        public void CreateTransaction_WhenXmlResponseDoesNotContainError_ShouldReturnCreateTransactionResponse() {
+            var service = new CieloServiceFake {
                 ReturnXml = @"<?xml version=""1.0"" encoding=""ISO-8859-1""?>
                                                         <transacao versao=""1.3.0"" id=""0dcb285b-fbb2-491c-ac58-d49e3b8b97c3"" xmlns=""http://ecommerce.cbmp.com.br"">
                                                           <tid>1001734898001D871001</tid>
@@ -59,10 +51,8 @@ namespace CieloTests
         }
 
         [Test]
-        public void CreateTransaction_WhenXmlResponseContainError_ShouldThrowsResponseException()
-        {
-            var service = new CieloServiceFake()
-            {
+        public void CreateTransaction_WhenXmlResponseContainError_ShouldThrowsResponseException() {
+            var service = new CieloServiceFake {
                 ReturnXml = @"<erro xmlns=""http://ecommerce.cbmp.com.br"">
                                   <codigo>014</codigo>
                                   <mensagem>Autorização Direta é permitida apenas para crédito.</mensagem>
@@ -71,17 +61,14 @@ namespace CieloTests
 
             Assert.That(() => service.CreateTransaction(new CreateTransactionRequest(null, null, null)),
                 Throws
-                .Exception
-                .TypeOf<ResponseException>()
-                .With.Property("Message")
-                .EqualTo("Autorização Direta é permitida apenas para crédito."));
+                    .TypeOf<ResponseException>()
+                    .With.InnerException.With.Property("Message")
+                    .EqualTo("Autorização Direta é permitida apenas para crédito."));
         }
 
         [Test]
-        public void CheckTransaction_WhenXmlResponseContainError_ShouldThrowsResponseExeception()
-        {
-            var service = new CieloServiceFake()
-            {
+        public void CheckTransaction_WhenXmlResponseContainError_ShouldThrowsResponseExeception() {
+            var service = new CieloServiceFake {
                 ReturnXml = @"<erro xmlns=""http://ecommerce.cbmp.com.br"">
                                   <codigo>014</codigo>
                                   <mensagem>Autorização Direta é permitida apenas para crédito.</mensagem>
@@ -90,17 +77,15 @@ namespace CieloTests
 
             Assert.That(() => service.CheckTransaction(new CheckTransactionRequest("Tid")),
                 Throws
-                .Exception
-                .TypeOf<ResponseException>()
-                .With.Property("Message")
-                .EqualTo("Autorização Direta é permitida apenas para crédito."));
+                    .TypeOf<ResponseException>()
+                    .With.InnerException
+                    .With.Property("Message")
+                    .EqualTo("Autorização Direta é permitida apenas para crédito."));
         }
 
         [Test]
-        public void CheckTransaction_WhenXmlResponseDoesNotContainError_ShouldReturnCheckTransactionResponse()
-        {
-            var service = new CieloServiceFake()
-            {
+        public void CheckTransaction_WhenXmlResponseDoesNotContainError_ShouldReturnCheckTransactionResponse() {
+            var service = new CieloServiceFake {
                 ReturnXml = @"<?xml version=""1.0"" encoding=""ISO-8859-1""?>
                                                         <transacao versao=""1.3.0"" id=""0dcb285b-fbb2-491c-ac58-d49e3b8b97c3"" xmlns=""http://ecommerce.cbmp.com.br"">
                                                           <tid>1001734898001D871001</tid>
@@ -126,6 +111,4 @@ namespace CieloTests
             response.Should().BeOfType<CheckTransactionResponse>();
         }
     }
-
-
 }

--- a/src/CieloTests/CreateTransactionRequestTests.cs
+++ b/src/CieloTests/CreateTransactionRequestTests.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using NUnit.Framework;
 
 namespace CieloTests {
+
     [TestFixture]
     public class CreateTransactionRequestTests {
 
@@ -48,7 +49,7 @@ namespace CieloTests {
                                         <numero>4551870000000183</numero>
                                         <validade>201508</validade>
                                         <indicador>1</indicador>
-                                        <codigo-seguranca>973</codigo-seguranca>
+                                        <codigo-seguranca>031</codigo-seguranca>
                                         <token/>
                                     </dados-portador>
                                     <dados-pedido>
@@ -121,7 +122,7 @@ namespace CieloTests {
             var order = new Order("624726783", 10.00m, new DateTime(2013, 02, 18, 16, 45, 12), "[origem:172.16.34.66]");
             var paymentMethod = new PaymentMethod(CreditCard.Visa, PurchaseType.Credit);
             var createTransactionOptions = new CreateTransactionOptions(AuthorizationType.AuthorizeSkippingAuthentication, capture: false);
-            var creditCardData = new CreditCardData("4551870000000183", new CreditCardExpiration(2015, 08), SecurityCodeIndicator.Sent, 973);
+            var creditCardData = new CreditCardData("4551870000000183", new CreditCardExpiration(2015, 08), SecurityCodeIndicator.Sent, "031");
             var fakeConfiguration = new FakeConfiguration();
 
             var createTransactionRequest = new CreateTransactionRequest(order, paymentMethod, createTransactionOptions, creditCardData, fakeConfiguration) {
@@ -137,11 +138,10 @@ namespace CieloTests {
 
         [Test]
         public void ToXmlWithoutSensitiveData_GivenACreateTransactionRequest_ShouldGenerateAXmlWithoutSensitiveDataAkaCreditCardNumberAndDateAndSecurityCode() {
-
             var order = new Order("624726783", 10.00m, new DateTime(2013, 02, 18, 16, 45, 12), "[origem:172.16.34.66]");
             var paymentMethod = new PaymentMethod(CreditCard.Visa, PurchaseType.Credit);
             var createTransactionOptions = new CreateTransactionOptions(AuthorizationType.AuthorizeSkippingAuthentication, capture: false);
-            var creditCardData = new CreditCardData("4551870000000183", new CreditCardExpiration(2015, 08), SecurityCodeIndicator.Sent, 973);
+            var creditCardData = new CreditCardData("4551870000000183", new CreditCardExpiration(2015, 08), SecurityCodeIndicator.Sent, "973");
             var fakeConfiguration = new FakeConfiguration();
 
             var createTransactionRequest = new CreateTransactionRequest(order, paymentMethod, createTransactionOptions, creditCardData, fakeConfiguration) {


### PR DESCRIPTION
When a user buys with a security code that starts with zero, Cielo returns the error below:

Cielo.Responses.Exceptions.ResponseException: O XML informado n o   valido: - string value '11' does not match pattern for type of codigo-seguranca element in DadosCartao in namespace http://ecommerce.cbmp.com.br: '<xml-fragment/>' 

This error occurs because the user input is, for example, 011 and the variable security code is a type int, so the left zero is removed sending only 11 to Cielo.
