### PR TITLE
Add method CancelTransaction to service interface

### DIFF
--- a/src/Cielo/ICieloService.cs
+++ b/src/Cielo/ICieloService.cs
@@ -7,5 +7,6 @@ namespace Cielo
     {
         CreateTransactionResponse CreateTransaction(CreateTransactionRequest request);
         CheckTransactionResponse CheckTransaction(CheckTransactionRequest request);
+        CancelTransactionResponse CancelTransaction(CancelTransactionRequest request);
     }
 }


### PR DESCRIPTION
Adicionei o método que já existia no serviço à interface ICieloService, pois não estava sendo possível utiliza-lo, somente quando utilizado a classe concreta
